### PR TITLE
Implement basic Palabra integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+config.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Real-Time Simultaneous Interpretation App
+
+This project aims to create a cross platform desktop application for real-time interpretation. It combines Palabra for speech recognition and translation, LiveKit for audio streaming, and uses SRT to send translated audio to remote endpoints.
+
+## Features
+
+- **Language Management**: choose a source language and multiple target languages. Each target language can be assigned one of Palabra's official presets:
+  - `transcribe_and_translate`
+  - `transcribe_and_translate_reliable`
+  - `transcribe_and_translate_fast`
+- **Audio Devices**: select microphone and speaker devices, with hot-swapping support while the session is active.
+- **API Validation**: on first launch the user is asked for Palabra and LiveKit credentials which are validated before allowing a session to start.
+- **Live Translation**: use Palabra's WebSocket API for real-time STT and translation. Languages and presets can be changed during a session.
+- **SRT Streaming**: translated text is converted to speech and streamed to user defined `srt://` endpoints. Each target language can have its own SRT destination.
+- **Monitoring**: connection status for Palabra, LiveKit and SRT streams are monitored and displayed in the UI. The app automatically retries on failures.
+
+## Getting Started
+
+The code base uses **Electron** and **Node.js**. Dependencies are declared in `package.json`. To start developing:
+
+```bash
+npm install
+npm start
+```
+
+> The dependencies are placeholders only – actual integration with Palabra, LiveKit and text-to-speech engines still needs to be implemented.
+
+On launch the application asks for your **Palabra** API key. You can obtain a key and view the API schema at [Palabra's OpenAPI docs](https://api.palabra.ai/docs/openapi.json). The key is used when establishing the WebSocket connection for real-time translation.
+
+The key is stored locally in `config.json` so you won't need to re-enter it each time.
+
+## Directory Structure
+
+```
+src/
+  main.js        - Electron main process
+  renderer.js    - Browser side logic
+  index.html     - Simple UI skeleton
+```
+
+## Status
+
+This is a work in progress. Core features such as API interaction, real-time audio transport and SRT output are currently stubs. Pull requests are welcome!
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "translator-agent",
+  "version": "0.1.0",
+  "description": "Real-time interpretation app using Palabra, LiveKit and SRT",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^25.3.1",
+    "ws": "^8.13.0"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, '..', 'config.json');
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  } catch {
+    return { palabraKey: '', livekitUrl: '' };
+  }
+}
+
+function save(cfg) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+}
+
+module.exports = { load, save, CONFIG_PATH };

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Translator Agent</title>
+</head>
+<body>
+  <h1>Translator Agent</h1>
+  <div id="status">Initializing...</div>
+  <div id="controls">
+    <label>Source Language:
+      <input id="sourceLang" placeholder="en" />
+    </label>
+    <button id="addTarget">Add Target Language</button>
+  </div>
+  <ul id="targets"></ul>
+  <button id="start">Start Session</button>
+
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,28 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/src/palabraClient.js
+++ b/src/palabraClient.js
@@ -1,0 +1,48 @@
+const WebSocket = require('ws');
+
+class PalabraClient {
+  constructor(apiKey, sourceLang, targets) {
+    this.apiKey = apiKey;
+    this.sourceLang = sourceLang;
+    this.targets = targets; // [{lang, preset}]
+    this.socket = null;
+  }
+
+  async connect() {
+    return new Promise((resolve, reject) => {
+      this.socket = new WebSocket('wss://api.palabra.ai/v1/ws', {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+      this.socket.on('open', () => resolve());
+      this.socket.on('error', (err) => reject(err));
+    });
+  }
+
+  startSession() {
+    if (!this.socket) return;
+    const config = {
+      action: 'start',
+      source_lang: this.sourceLang,
+      targets: this.targets,
+    };
+    this.socket.send(JSON.stringify(config));
+  }
+
+  onTranslation(callback) {
+    if (!this.socket) return;
+    this.socket.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data);
+        callback(msg);
+      } catch (err) {
+        console.error('Failed to parse message from Palabra:', err);
+      }
+    });
+  }
+
+  close() {
+    if (this.socket) this.socket.close();
+  }
+}
+
+module.exports = PalabraClient;

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,3 @@
+window.addEventListener('DOMContentLoaded', () => {
+  // Placeholder for future context bridging if needed
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,46 @@
+const targetsUl = document.getElementById('targets');
+const addBtn = document.getElementById('addTarget');
+const startBtn = document.getElementById('start');
+const statusDiv = document.getElementById('status');
+const sourceInput = document.getElementById('sourceLang');
+
+const PalabraClient = require('./palabraClient');
+const config = require('./config');
+
+let targets = [];
+let palabraClient = null;
+let cfg = config.load();
+
+addBtn.onclick = () => {
+  const lang = prompt('Target language code (e.g. es, fr):');
+  if (!lang) return;
+  const preset = prompt('Preset (transcribe_and_translate | transcribe_and_translate_reliable | transcribe_and_translate_fast):', 'transcribe_and_translate');
+  const li = document.createElement('li');
+  li.textContent = `${lang} - ${preset}`;
+  targetsUl.appendChild(li);
+  targets.push({ lang, preset });
+};
+
+startBtn.onclick = async () => {
+  const sourceLang = sourceInput.value || 'en';
+  if (!cfg.palabraKey) {
+    cfg.palabraKey = prompt('Enter Palabra API key:') || '';
+    config.save(cfg);
+  }
+  statusDiv.textContent = 'Connecting to Palabra...';
+
+  palabraClient = new PalabraClient(cfg.palabraKey, sourceLang, targets);
+
+  try {
+    await palabraClient.connect();
+    palabraClient.startSession();
+    statusDiv.textContent = 'Session started';
+
+    palabraClient.onTranslation((msg) => {
+      console.log('Translation update:', msg);
+    });
+  } catch (err) {
+    console.error('Failed to connect to Palabra:', err);
+    statusDiv.textContent = 'Failed to connect to Palabra';
+  }
+};


### PR DESCRIPTION
## Summary
- create `.gitignore`
- add a config helper and `palabraClient` for WebSocket sessions
- persist Palabra API key to `config.json`
- connect to Palabra from the renderer and handle translations
- document API key usage in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685874e63a988325ac1e31e15038277a