### PR TITLE
Add LiveKit credential support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm start
 On launch the application asks for your **Palabra** API key. You can obtain a key and view the API schema at [Palabra's OpenAPI docs](https://api.palabra.ai/docs/openapi.json). The key is used when establishing the WebSocket connection for real-time translation.
 
 The key is stored locally in `config.json` so you won't need to re-enter it each time.
+LiveKit connection details (`livekitUrl`, `livekitApiKey` and `livekitApiSecret`) are stored in the same file and will be requested if missing.
 
 ## Directory Structure
 

--- a/src/config.js
+++ b/src/config.js
@@ -6,10 +6,18 @@ const userData = ipcRenderer.sendSync('get-user-data-path');
 const CONFIG_PATH = path.join(userData, 'config.json');
 
 function load() {
+  const defaults = {
+    palabraKey: '',
+    livekitUrl: '',
+    livekitApiKey: '',
+    livekitApiSecret: '',
+  };
+
   try {
-    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    return { ...defaults, ...data };
   } catch {
-    return { palabraKey: '', livekitUrl: '' };
+    return defaults;
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
       <input id="sourceLang" placeholder="en" />
     </label>
     <button id="addTarget">Add Target Language</button>
+    <button id="setCreds">Set API Credentials</button>
   </div>
   <ul id="targets"></ul>
   <button id="start">Start Session</button>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,6 +3,7 @@ const addBtn = document.getElementById('addTarget');
 const startBtn = document.getElementById('start');
 const statusDiv = document.getElementById('status');
 const sourceInput = document.getElementById('sourceLang');
+const setCredsBtn = document.getElementById('setCreds');
 
 const PalabraClient = require('./palabraClient');
 const config = require('./config');
@@ -10,6 +11,18 @@ const config = require('./config');
 let targets = [];
 let palabraClient = null;
 let cfg = config.load();
+
+function promptCredentials() {
+  cfg.palabraKey = prompt('Enter Palabra API key:', cfg.palabraKey || '') || cfg.palabraKey || '';
+  cfg.livekitUrl = prompt('Enter LiveKit URL:', cfg.livekitUrl || '') || cfg.livekitUrl || '';
+  cfg.livekitApiKey = prompt('Enter LiveKit API key:', cfg.livekitApiKey || '') || cfg.livekitApiKey || '';
+  cfg.livekitApiSecret = prompt('Enter LiveKit API secret:', cfg.livekitApiSecret || '') || cfg.livekitApiSecret || '';
+  config.save(cfg);
+}
+
+setCredsBtn.onclick = () => {
+  promptCredentials();
+};
 
 addBtn.onclick = () => {
   const lang = prompt('Target language code (e.g. es, fr):');
@@ -23,9 +36,8 @@ addBtn.onclick = () => {
 
 startBtn.onclick = async () => {
   const sourceLang = sourceInput.value || 'en';
-  if (!cfg.palabraKey) {
-    cfg.palabraKey = prompt('Enter Palabra API key:') || '';
-    config.save(cfg);
+  if (!cfg.palabraKey || !cfg.livekitUrl || !cfg.livekitApiKey || !cfg.livekitApiSecret) {
+    promptCredentials();
   }
   statusDiv.textContent = 'Connecting to Palabra...';
 


### PR DESCRIPTION
## Summary
- expand config to store LiveKit credentials
- add a button in the UI for setting API credentials
- prompt for LiveKit values when starting a session
- document new configuration fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685878251d5c83259641490f402f1606