### PR TITLE
Handle Palabra connection lifecycle

### DIFF
--- a/src/palabraClient.js
+++ b/src/palabraClient.js
@@ -1,25 +1,59 @@
 const WebSocket = require('ws');
+const { EventEmitter } = require('events');
 
-class PalabraClient {
+class PalabraClient extends EventEmitter {
   constructor(apiKey, sourceLang, targets) {
+    super();
     this.apiKey = apiKey;
     this.sourceLang = sourceLang;
     this.targets = targets; // [{lang, preset}]
     this.socket = null;
+    this.shouldReconnect = false;
+    this.reconnectAttempts = 0;
+    this.startOnConnect = false;
+    this.translationCallbacks = [];
   }
 
   async connect() {
+    this.shouldReconnect = true;
+    return this._connect(true);
+  }
+
+  _connect(isFirst) {
     return new Promise((resolve, reject) => {
+      this.emit('status', isFirst ? 'connecting' : 'reconnecting');
       this.socket = new WebSocket('wss://api.palabra.ai/v1/ws', {
         headers: { Authorization: `Bearer ${this.apiKey}` },
       });
-      this.socket.on('open', () => resolve());
-      this.socket.on('error', (err) => reject(err));
+
+      this.socket.once('open', () => {
+        this.reconnectAttempts = 0;
+        this.emit('status', 'connected');
+        this._attachMessageHandlers();
+        if (this.startOnConnect) this._sendStart();
+        resolve();
+      });
+
+      this.socket.once('error', (err) => {
+        this.emit('status', 'error');
+        if (isFirst) reject(err);
+      });
+
+      this.socket.once('close', () => {
+        this.emit('status', 'closed');
+        if (this.shouldReconnect) this._scheduleReconnect();
+      });
     });
   }
 
-  startSession() {
-    if (!this.socket) return;
+  _scheduleReconnect() {
+    this.reconnectAttempts += 1;
+    const delay = Math.min(10000, 1000 * 2 ** (this.reconnectAttempts - 1));
+    setTimeout(() => this._connect(false), delay);
+  }
+
+  _sendStart() {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
     const config = {
       action: 'start',
       source_lang: this.sourceLang,
@@ -28,19 +62,40 @@ class PalabraClient {
     this.socket.send(JSON.stringify(config));
   }
 
+  startSession() {
+    this.startOnConnect = true;
+    this._sendStart();
+  }
+
   onTranslation(callback) {
-    if (!this.socket) return;
-    this.socket.on('message', (data) => {
-      try {
-        const msg = JSON.parse(data);
-        callback(msg);
-      } catch (err) {
-        console.error('Failed to parse message from Palabra:', err);
-      }
-    });
+    this.translationCallbacks.push(callback);
+    if (this.socket) {
+      this.socket.on('message', (data) => {
+        try {
+          const msg = JSON.parse(data);
+          callback(msg);
+        } catch (err) {
+          console.error('Failed to parse message from Palabra:', err);
+        }
+      });
+    }
+  }
+
+  _attachMessageHandlers() {
+    for (const cb of this.translationCallbacks) {
+      this.socket.on('message', (data) => {
+        try {
+          const msg = JSON.parse(data);
+          cb(msg);
+        } catch (err) {
+          console.error('Failed to parse message from Palabra:', err);
+        }
+      });
+    }
   }
 
   close() {
+    this.shouldReconnect = false;
     if (this.socket) this.socket.close();
   }
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -43,10 +43,29 @@ startBtn.onclick = async () => {
 
   palabraClient = new PalabraClient(cfg.palabraKey, sourceLang, targets);
 
+  palabraClient.on('status', (s) => {
+    switch (s) {
+      case 'connecting':
+        statusDiv.textContent = 'Connecting to Palabra...';
+        break;
+      case 'connected':
+        statusDiv.textContent = 'Connected to Palabra';
+        break;
+      case 'reconnecting':
+        statusDiv.textContent = 'Reconnecting to Palabra...';
+        break;
+      case 'closed':
+        statusDiv.textContent = 'Connection closed';
+        break;
+      case 'error':
+        statusDiv.textContent = 'Connection error';
+        break;
+    }
+  });
+
   try {
     await palabraClient.connect();
     palabraClient.startSession();
-    statusDiv.textContent = 'Session started';
 
     palabraClient.onTranslation((msg) => {
       console.log('Translation update:', msg);


### PR DESCRIPTION
## Summary
- listen for WebSocket close and error events
- automatically reconnect with exponential backoff
- emit connection status changes so the renderer can react
- show live status updates in the renderer

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858782960f48325984d92a74e2b0720